### PR TITLE
Properly check if bundle is CCBundleTypeDefault

### DIFF
--- a/CCSectionViewController.xm
+++ b/CCSectionViewController.xm
@@ -280,7 +280,7 @@
 
 %new
 - (void)_CCLoader_controlCenterDidDisappear {
-    if (selfBundleType && CCBundleTypeDefault && [selfSection respondsToSelector:@selector(controlCenterDidDisappear)]) {
+    if (selfBundleType == CCBundleTypeDefault && [selfSection respondsToSelector:@selector(controlCenterDidDisappear)]) {
         [selfSection controlCenterDidDisappear];
     }
     else if (selfBundleType == CCBundleTypeBBWeeApp) {


### PR DESCRIPTION
Needed for controlCenterWillAppear and controlCenterDidDisappear to be called.
