### PR TITLE
fixes for +(BOOL)isUnavailable

### DIFF
--- a/CCLoader.xm
+++ b/CCLoader.xm
@@ -165,19 +165,22 @@ NS_INLINE NSMutableArray *sectionViewControllersForIDs(NSArray *IDs, NSDictionar
         else {
             CCSectionViewController *sectionViewController = customSectionViewControllers[sectionIdentifier];
             
-            if (!sectionViewController) {
+            Class principalClass = loadingBundle.principalClass;
+            BOOL available = !([principalClass respondsToSelector:@selector(isUnavailable)] && [principalClass isUnavailable]);
+                        
+            if (!sectionViewController && available) {
                 sectionViewController = [[%c(CCSectionViewController) alloc] initWithCCLoaderBundle:loadingBundle type:type];
-                if(sectionViewController) {
-                	[sectionViewController setDelegate:viewController];
-                	customSectionViewControllers[sectionIdentifier] = sectionViewController;
-                	[sectionViewController release];
-                }
+                [sectionViewController setDelegate:viewController];
+                customSectionViewControllers[sectionIdentifier] = sectionViewController;
+                [sectionViewController release];
+            }else{
+            	[customSectionViewControllers removeObjectForKey:sectionIdentifier]; // remove if was added before
+	            [loadingBundle unload];
             }
             
             if (cleanUnusedSections) {
                 [usedCustomSections removeObject:sectionIdentifier];
             }
-            
             
             if (!sectionViewController) {
                 if (fallbackToStockSection) {

--- a/CCLoader.xm
+++ b/CCLoader.xm
@@ -167,11 +167,11 @@ NS_INLINE NSMutableArray *sectionViewControllersForIDs(NSArray *IDs, NSDictionar
             
             if (!sectionViewController) {
                 sectionViewController = [[%c(CCSectionViewController) alloc] initWithCCLoaderBundle:loadingBundle type:type];
-                [sectionViewController setDelegate:viewController];
-                
-                customSectionViewControllers[sectionIdentifier] = sectionViewController;
-                
-                [sectionViewController release];
+                if(sectionViewController) {
+                	[sectionViewController setDelegate:viewController];
+                	customSectionViewControllers[sectionIdentifier] = sectionViewController;
+                	[sectionViewController release];
+                }
             }
             
             if (cleanUnusedSections) {

--- a/CCSectionViewController.xm
+++ b/CCSectionViewController.xm
@@ -83,7 +83,7 @@
         }
         
         if (type == CCBundleTypeDefault && [principalClass respondsToSelector:@selector(isUnavailable)]) {
-            if (![principalClass isUnavailable]) {
+            if ([principalClass isUnavailable]) {
                 [self release];
                 self = nil;
                 return nil;

--- a/CCSectionViewController.xm
+++ b/CCSectionViewController.xm
@@ -82,14 +82,6 @@
             principalClass = [bundle principalClass];
         }
         
-        if (type == CCBundleTypeDefault && [principalClass respondsToSelector:@selector(isUnavailable)]) {
-            if ([principalClass isUnavailable]) {
-                [self release];
-                self = nil;
-                return nil;
-            }
-        }
-        
         _SBUIWidgetViewController <CCSection, BBWeeAppController> *section = [[principalClass alloc] init];
 
         if (type == CCBundleTypeWeeApp) {


### PR DESCRIPTION
in CCSectionViewController.xm :
- isUnavailable should return YES when not available in that case
  CCSectionViewController should return nil;
  - it could even be removed from here to not initialize the object
    without reason and check directly before the allocation, would just be
    an optmization, I guess is okay

in CCLoader.xm :
- if the initializer return nil, set it in the dictionary would cause
  a crash
